### PR TITLE
Fix clang warning for missing DependentPointer handling in switch.

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -3533,7 +3533,7 @@ class DependentPointerType : public Type,
 
 public:
   QualType getPointerType() const { return PointerType; }
-  SourceLocation getQualifierLoc() const { return Loc; }
+  SourceLocation getAttributeLoc() const { return Loc; }
 
   bool isSugared() const { return false; }
   QualType desugar() const { return QualType(this, 0); }

--- a/clang/include/clang/AST/TypeProperties.td
+++ b/clang/include/clang/AST/TypeProperties.td
@@ -668,13 +668,13 @@ let Class = DependentPointerType in {
   def : Property<"pointerInterpretation", PointerInterpretationKind> {
     let Read = [{ node->getPointerInterpretation() }];
   }
-  def : Property<"qualifierLoc", SourceLocation> {
-    let Read = [{ node->getQualifierLoc() }];
+  def : Property<"attributeloc", SourceLocation> {
+    let Read = [{ node->getAttributeLoc() }];
   }
 
   def : Creator<[{
     return ctx.getDependentPointerType(pointerType, pointerInterpretation,
-                                       qualifierLoc);
+                                       attributeloc);
   }]>;
 }
 

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -13111,6 +13111,14 @@ static QualType getCommonNonSugarTypeNode(ASTContext &Ctx, const Type *X,
                                             PX->getAddrSpaceExpr(),
                                             getCommonAttrLoc(PX, PY));
   }
+  case Type::DependentPointer: {
+    const auto *PX = cast<DependentPointerType>(X),
+               *PY = cast<DependentPointerType>(Y);
+    assert(PX->getPointerInterpretation() == PY->getPointerInterpretation());
+    return Ctx.getDependentPointerType(getCommonPointeeType(Ctx, PX, PY),
+                                       PX->getPointerInterpretation(),
+                                       getCommonAttrLoc(PX, PY));
+  }
   case Type::FunctionNoProto: {
     const auto *FX = cast<FunctionNoProtoType>(X),
                *FY = cast<FunctionNoProtoType>(Y);

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -5774,7 +5774,7 @@ QualType TreeTransform<Derived>::TransformDependentPointerType(
   QualType Result = TL.getType();
   if (getDerived().AlwaysRebuild() || PointerType != T->getPointerType()) {
     Result = getDerived().RebuildDependentPointerType(
-        PointerType, T->getPointerInterpretation(), T->getQualifierLoc());
+        PointerType, T->getPointerInterpretation(), T->getAttributeLoc());
     if (Result.isNull())
       return QualType();
   }


### PR DESCRIPTION
I don't think CHERIoT uses this, but I made a good-faith effort to implement it as intended.
Open to suggestions on how to write a test for this.
